### PR TITLE
Add WPF astrophotography processor and stacking app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Build output
+bin/
+obj/
+
+# Visual Studio
+.vs/
+*.user
+*.userosscache
+*.suo
+
+# MSBuild
+*.cache
+
+# Other
+GeneratedArtifacts/
+_Backup*/
+UpgradeLog*.XML
+*.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Skidbladnir Image Processor
+
+Skidbladnir Image Processor is a lightweight Windows desktop application for automating the first steps of deep sky image processing.  It automatically pre-processes every light frame that you load and then combines the frames with average stacking to produce a clean master image.
+
+## Features
+
+- Load multiple TIFF, PNG, JPEG or BMP light frames in one step.
+- Automatic background neutralisation, histogram stretching, gamma correction, light noise reduction and saturation boost for every frame.
+- Instant preview of the processed single frame.
+- Average stacking of all processed frames with additional refinement.
+- Save the stacked result as TIFF, PNG or JPEG.
+
+## Project structure
+
+```
+SkidbladnirProcessor.sln               # Visual Studio solution
+src/SkidbladnirProcessor.App/          # WPF application
+```
+
+The application is built with .NET 7, WPF and [ImageSharp](https://github.com/SixLabors/ImageSharp) for the processing pipeline.
+
+## Getting started
+
+1. Install the [.NET 7 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) on a Windows machine.
+2. Clone the repository and open a Developer Command Prompt.
+3. Restore the dependencies and build the application:
+
+   ```bash
+   dotnet restore
+   dotnet build SkidbladnirProcessor.sln
+   ```
+
+4. Run the application:
+
+   ```bash
+   dotnet run --project src/SkidbladnirProcessor.App/SkidbladnirProcessor.App.csproj
+   ```
+
+   or open the solution in Visual Studio and press <kbd>F5</kbd>.
+
+## Usage tips
+
+1. Click **Load Light Frames** and select the light frames that you want to process.
+2. Inspect the automatically processed preview for every frame from the list on the left.
+3. When you are satisfied click **Stack Images** to build an averaged master frame.
+4. Use **Save Stacked Result** to export the combined image.
+
+> **Note:** The repository is prepared on a Linux build host where Windows-specific workloads cannot be executed.  Building the solution locally on Windows is therefore required.

--- a/SkidbladnirProcessor.sln
+++ b/SkidbladnirProcessor.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32922.545
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkidbladnirProcessor.App", "src/SkidbladnirProcessor.App/SkidbladnirProcessor.App.csproj", "{56ECA4BB-77E5-49CE-8120-DBCF99C44A1D}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {56ECA4BB-77E5-49CE-8120-DBCF99C44A1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {56ECA4BB-77E5-49CE-8120-DBCF99C44A1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {56ECA4BB-77E5-49CE-8120-DBCF99C44A1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {56ECA4BB-77E5-49CE-8120-DBCF99C44A1D}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal

--- a/src/SkidbladnirProcessor.App/App.xaml
+++ b/src/SkidbladnirProcessor.App/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="SkidbladnirProcessor.App.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/src/SkidbladnirProcessor.App/App.xaml.cs
+++ b/src/SkidbladnirProcessor.App/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace SkidbladnirProcessor.App;
+
+public partial class App : Application
+{
+}

--- a/src/SkidbladnirProcessor.App/MainWindow.xaml
+++ b/src/SkidbladnirProcessor.App/MainWindow.xaml
@@ -1,0 +1,56 @@
+<Window x:Class="SkidbladnirProcessor.App.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="Skidbladnir Image Processor" Height="720" Width="1200" MinWidth="1000" MinHeight="600">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,10" HorizontalAlignment="Left" Spacing="8">
+            <Button x:Name="LoadButton" Content="Load Light Frames" Width="150" Click="LoadButton_Click" />
+            <Button x:Name="ClearButton" Content="Clear" Width="90" Click="ClearButton_Click" />
+            <Button x:Name="StackButton" Content="Stack Images" Width="140" Click="StackButton_Click" />
+            <Button x:Name="SaveButton" Content="Save Stacked Result" Width="170" Click="SaveButton_Click" />
+        </StackPanel>
+
+        <Grid Grid.Row="1" ColumnGap="10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*" />
+                <ColumnDefinition Width="3*" />
+                <ColumnDefinition Width="3*" />
+            </Grid.ColumnDefinitions>
+
+            <GroupBox Header="Light Frames" Grid.Column="0">
+                <ListBox x:Name="FramesList" DisplayMemberPath="FileName" SelectionChanged="FramesList_SelectionChanged" />
+            </GroupBox>
+
+            <GroupBox Header="Processed Preview" Grid.Column="1">
+                <Border Background="Black" Margin="5">
+                    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                        <Image x:Name="PreviewImage" Stretch="Uniform" />
+                    </ScrollViewer>
+                </Border>
+            </GroupBox>
+
+            <GroupBox Header="Stacked Result" Grid.Column="2">
+                <Border Background="Black" Margin="5">
+                    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                        <Image x:Name="StackedImage" Stretch="Uniform" />
+                    </ScrollViewer>
+                </Border>
+            </GroupBox>
+        </Grid>
+
+        <StatusBar Grid.Row="2" Margin="0,10,0,0">
+            <StatusBarItem>
+                <TextBlock x:Name="StatusText" Text="Ready" />
+            </StatusBarItem>
+        </StatusBar>
+    </Grid>
+</Window>

--- a/src/SkidbladnirProcessor.App/MainWindow.xaml.cs
+++ b/src/SkidbladnirProcessor.App/MainWindow.xaml.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media.Imaging;
+using Microsoft.Win32;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SkidbladnirProcessor.App.Processing;
+using SkidbladnirProcessor.App.Services;
+using SkidbladnirProcessor.App.ViewModels;
+
+namespace SkidbladnirProcessor.App;
+
+public partial class MainWindow : Window
+{
+    private readonly ObservableCollection<ProcessedImageViewModel> _frames = new();
+    private Image<Rgba32>? _stackedImageData;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+        FramesList.ItemsSource = _frames;
+    }
+
+    private async void LoadButton_Click(object sender, RoutedEventArgs e)
+    {
+        var dialog = new OpenFileDialog
+        {
+            Filter = "Image files (*.tif;*.tiff;*.png;*.jpg;*.jpeg;*.bmp)|*.tif;*.tiff;*.png;*.jpg;*.jpeg;*.bmp|All files (*.*)|*.*",
+            Multiselect = true,
+            Title = "Select light frames to process"
+        };
+
+        if (dialog.ShowDialog() != true)
+        {
+            return;
+        }
+
+        ToggleUi(false);
+        try
+        {
+            foreach (var file in dialog.FileNames)
+            {
+                StatusText.Text = $"Processing {Path.GetFileName(file)}";
+                var processed = await Task.Run(() => AstroImageProcessor.Process(file));
+                _frames.Add(processed);
+            }
+
+            StatusText.Text = $"Loaded {_frames.Count} frame(s).";
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(this, $"Failed to process images. {ex.Message}", "Processing error", MessageBoxButton.OK, MessageBoxImage.Error);
+            StatusText.Text = "Processing failed.";
+        }
+        finally
+        {
+            ToggleUi(true);
+        }
+    }
+
+    private void FramesList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (FramesList.SelectedItem is ProcessedImageViewModel selected)
+        {
+            PreviewImage.Source = selected.Preview;
+            StatusText.Text = $"Previewing {selected.FileName}";
+        }
+        else
+        {
+            PreviewImage.Source = null;
+        }
+    }
+
+    private async void StackButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_frames.Count == 0)
+        {
+            MessageBox.Show(this, "Add at least one processed frame before stacking.", "Nothing to stack", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        ToggleUi(false);
+        try
+        {
+            StatusText.Text = "Stacking frames...";
+            _stackedImageData?.Dispose();
+
+            var imagesToStack = _frames.Select(frame => frame.ImageData).ToList();
+            _stackedImageData = await Task.Run(() =>
+            {
+                var stacked = ImageStackingService.AverageStack(imagesToStack);
+                AstroImageProcessor.RefineStackedImage(stacked);
+                return stacked;
+            });
+
+            StackedImage.Source = BitmapSourceConverter.FromImage(_stackedImageData);
+            StatusText.Text = "Stacking completed.";
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(this, $"Failed to stack frames. {ex.Message}", "Stacking error", MessageBoxButton.OK, MessageBoxImage.Error);
+            StatusText.Text = "Stacking failed.";
+        }
+        finally
+        {
+            ToggleUi(true);
+        }
+    }
+
+    private void ClearButton_Click(object sender, RoutedEventArgs e)
+    {
+        foreach (var frame in _frames)
+        {
+            frame.Dispose();
+        }
+
+        _frames.Clear();
+        PreviewImage.Source = null;
+        StackedImage.Source = null;
+        _stackedImageData?.Dispose();
+        _stackedImageData = null;
+        StatusText.Text = "Cleared all frames.";
+    }
+
+    private void SaveButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_stackedImageData is null)
+        {
+            MessageBox.Show(this, "Stack the images before saving the combined frame.", "No stacked image", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        var dialog = new SaveFileDialog
+        {
+            Title = "Save stacked image",
+            Filter = "TIFF image (*.tif)|*.tif|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg",
+            FileName = "StackedResult.tif"
+        };
+
+        if (dialog.ShowDialog() != true)
+        {
+            return;
+        }
+
+        try
+        {
+            using var stream = File.Create(dialog.FileName);
+            var extension = Path.GetExtension(dialog.FileName).ToLowerInvariant();
+            switch (extension)
+            {
+                case ".png":
+                    _stackedImageData.SaveAsPng(stream);
+                    break;
+                case ".jpg":
+                case ".jpeg":
+                    _stackedImageData.SaveAsJpeg(stream);
+                    break;
+                default:
+                    _stackedImageData.SaveAsTiff(stream);
+                    break;
+            }
+
+            StatusText.Text = $"Saved {Path.GetFileName(dialog.FileName)}.";
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(this, $"Unable to save the stacked image. {ex.Message}", "Save error", MessageBoxButton.OK, MessageBoxImage.Error);
+            StatusText.Text = "Saving failed.";
+        }
+    }
+
+    private void ToggleUi(bool isEnabled)
+    {
+        LoadButton.IsEnabled = isEnabled;
+        ClearButton.IsEnabled = isEnabled;
+        StackButton.IsEnabled = isEnabled;
+        SaveButton.IsEnabled = isEnabled;
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        base.OnClosed(e);
+        foreach (var frame in _frames)
+        {
+            frame.Dispose();
+        }
+
+        _stackedImageData?.Dispose();
+    }
+}

--- a/src/SkidbladnirProcessor.App/Processing/AstroImageProcessor.cs
+++ b/src/SkidbladnirProcessor.App/Processing/AstroImageProcessor.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Numerics;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using SkidbladnirProcessor.App.Services;
+using SkidbladnirProcessor.App.ViewModels;
+
+namespace SkidbladnirProcessor.App.Processing;
+
+public static class AstroImageProcessor
+{
+    public static ProcessedImageViewModel Process(string filePath)
+    {
+        var image = Image.Load<Rgba32>(filePath);
+        image.Mutate(ctx => ctx.AutoOrient());
+
+        NormalizeChannels(image);
+        StretchHistogram(image);
+        ApplyGamma(image, 0.85d);
+        ReduceNoise(image);
+        BoostSaturation(image, 1.15f);
+
+        var preview = BitmapSourceConverter.FromImage(image);
+        return new ProcessedImageViewModel(filePath, image, preview);
+    }
+
+    public static void RefineStackedImage(Image<Rgba32> stacked)
+    {
+        NormalizeChannels(stacked);
+        StretchHistogram(stacked);
+        ApplyGamma(stacked, 0.9d);
+        BoostSaturation(stacked, 1.08f);
+    }
+
+    private static void NormalizeChannels(Image<Rgba32> image)
+    {
+        double sumR = 0;
+        double sumG = 0;
+        double sumB = 0;
+        var pixelCount = image.Width * image.Height;
+
+        for (var y = 0; y < image.Height; y++)
+        {
+            var row = image.GetPixelRowSpan(y);
+            for (var x = 0; x < row.Length; x++)
+            {
+                var pixel = row[x];
+                sumR += pixel.R;
+                sumG += pixel.G;
+                sumB += pixel.B;
+            }
+        }
+
+        var avgR = sumR / pixelCount;
+        var avgG = sumG / pixelCount;
+        var avgB = sumB / pixelCount;
+        var target = (avgR + avgG + avgB) / 3d;
+
+        var scaleR = avgR > 0 ? target / avgR : 1d;
+        var scaleG = avgG > 0 ? target / avgG : 1d;
+        var scaleB = avgB > 0 ? target / avgB : 1d;
+
+        for (var y = 0; y < image.Height; y++)
+        {
+            var row = image.GetPixelRowSpan(y);
+            for (var x = 0; x < row.Length; x++)
+            {
+                ref var pixel = ref row[x];
+                pixel.R = ClampToByte(pixel.R * scaleR);
+                pixel.G = ClampToByte(pixel.G * scaleG);
+                pixel.B = ClampToByte(pixel.B * scaleB);
+            }
+        }
+    }
+
+    private static void StretchHistogram(Image<Rgba32> image)
+    {
+        Span<int> histogram = stackalloc int[256];
+        var pixelCount = image.Width * image.Height;
+
+        for (var y = 0; y < image.Height; y++)
+        {
+            var row = image.GetPixelRowSpan(y);
+            for (var x = 0; x < row.Length; x++)
+            {
+                var pixel = row[x];
+                var luminance = 0.2126 * pixel.R + 0.7152 * pixel.G + 0.0722 * pixel.B;
+                var index = (int)Math.Clamp(Math.Round(luminance), 0, 255);
+                histogram[index]++;
+            }
+        }
+
+        var lowThreshold = (int)(pixelCount * 0.01);
+        var highThreshold = (int)(pixelCount * 0.99);
+
+        var cumulative = 0;
+        var low = 0;
+        for (var i = 0; i < histogram.Length; i++)
+        {
+            cumulative += histogram[i];
+            if (cumulative >= lowThreshold)
+            {
+                low = i;
+                break;
+            }
+        }
+
+        cumulative = 0;
+        var high = 255;
+        for (var i = 0; i < histogram.Length; i++)
+        {
+            cumulative += histogram[i];
+            if (cumulative >= highThreshold)
+            {
+                high = i;
+                break;
+            }
+        }
+
+        if (high <= low)
+        {
+            high = Math.Min(255, low + 1);
+            low = Math.Max(0, high - 1);
+        }
+
+        var scale = 255f / Math.Max(1, high - low);
+
+        for (var y = 0; y < image.Height; y++)
+        {
+            var row = image.GetPixelRowSpan(y);
+            for (var x = 0; x < row.Length; x++)
+            {
+                ref var pixel = ref row[x];
+                pixel.R = StretchChannel(pixel.R, low, scale);
+                pixel.G = StretchChannel(pixel.G, low, scale);
+                pixel.B = StretchChannel(pixel.B, low, scale);
+            }
+        }
+    }
+
+    private static void ApplyGamma(Image<Rgba32> image, double gamma)
+    {
+        var inverse = 1d / gamma;
+
+        for (var y = 0; y < image.Height; y++)
+        {
+            var row = image.GetPixelRowSpan(y);
+            for (var x = 0; x < row.Length; x++)
+            {
+                ref var pixel = ref row[x];
+                pixel.R = ApplyGamma(pixel.R, inverse);
+                pixel.G = ApplyGamma(pixel.G, inverse);
+                pixel.B = ApplyGamma(pixel.B, inverse);
+            }
+        }
+    }
+
+    private static void ReduceNoise(Image<Rgba32> image)
+    {
+        using var clone = image.Clone();
+
+        for (var y = 0; y < image.Height; y++)
+        {
+            var destinationRow = image.GetPixelRowSpan(y);
+            var originalRow = clone.GetPixelRowSpan(y);
+            for (var x = 0; x < destinationRow.Length; x++)
+            {
+                var smoothed = SmoothPixel(clone, x, y);
+                var original = originalRow[x];
+                var blended = new Vector3(original.R, original.G, original.B) * 0.4f + smoothed * 0.6f;
+                destinationRow[x] = new Rgba32(
+                    (byte)Math.Clamp((int)MathF.Round(blended.X), 0, 255),
+                    (byte)Math.Clamp((int)MathF.Round(blended.Y), 0, 255),
+                    (byte)Math.Clamp((int)MathF.Round(blended.Z), 0, 255),
+                    255);
+            }
+        }
+    }
+
+    private static void BoostSaturation(Image<Rgba32> image, float factor)
+    {
+        for (var y = 0; y < image.Height; y++)
+        {
+            var row = image.GetPixelRowSpan(y);
+            for (var x = 0; x < row.Length; x++)
+            {
+                ref var pixel = ref row[x];
+                var gray = (pixel.R + pixel.G + pixel.B) / 3f;
+                pixel.R = ClampToByte(gray + (pixel.R - gray) * factor);
+                pixel.G = ClampToByte(gray + (pixel.G - gray) * factor);
+                pixel.B = ClampToByte(gray + (pixel.B - gray) * factor);
+            }
+        }
+    }
+
+    private static Vector3 SmoothPixel(Image<Rgba32> source, int x, int y)
+    {
+        var width = source.Width;
+        var height = source.Height;
+        var sum = Vector3.Zero;
+        var count = 0;
+
+        for (var offsetY = -1; offsetY <= 1; offsetY++)
+        {
+            var sampleY = y + offsetY;
+            if ((uint)sampleY >= (uint)height)
+            {
+                continue;
+            }
+
+            var row = source.GetPixelRowSpan(sampleY);
+            for (var offsetX = -1; offsetX <= 1; offsetX++)
+            {
+                var sampleX = x + offsetX;
+                if ((uint)sampleX >= (uint)width)
+                {
+                    continue;
+                }
+
+                var pixel = row[sampleX];
+                sum += new Vector3(pixel.R, pixel.G, pixel.B);
+                count++;
+            }
+        }
+
+        return count == 0 ? Vector3.Zero : sum / count;
+    }
+
+    private static byte StretchChannel(byte value, int blackPoint, float scale)
+    {
+        var adjusted = (value - blackPoint) * scale;
+        return (byte)Math.Clamp((int)Math.Round(adjusted), 0, 255);
+    }
+
+    private static byte ApplyGamma(byte value, double inverseGamma)
+    {
+        var normalized = value / 255d;
+        var corrected = Math.Pow(normalized, inverseGamma);
+        return (byte)Math.Clamp((int)Math.Round(corrected * 255d), 0, 255);
+    }
+
+    private static byte ClampToByte(double value)
+    {
+        return (byte)Math.Clamp((int)Math.Round(value), 0, 255);
+    }
+}

--- a/src/SkidbladnirProcessor.App/Services/BitmapSourceConverter.cs
+++ b/src/SkidbladnirProcessor.App/Services/BitmapSourceConverter.cs
@@ -1,0 +1,21 @@
+using System.IO;
+using System.Windows.Media.Imaging;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Bmp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SkidbladnirProcessor.App.Services;
+
+public static class BitmapSourceConverter
+{
+    public static BitmapSource FromImage(Image<Rgba32> image)
+    {
+        using var stream = new MemoryStream();
+        image.Save(stream, new BmpEncoder());
+        stream.Position = 0;
+        var decoder = BitmapDecoder.Create(stream, BitmapCreateOptions.PreservePixelFormat, BitmapCacheOption.OnLoad);
+        var frame = decoder.Frames[0];
+        frame.Freeze();
+        return frame;
+    }
+}

--- a/src/SkidbladnirProcessor.App/Services/ImageStackingService.cs
+++ b/src/SkidbladnirProcessor.App/Services/ImageStackingService.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SkidbladnirProcessor.App.Services;
+
+public static class ImageStackingService
+{
+    public static Image<Rgba32> AverageStack(IReadOnlyList<Image<Rgba32>> images)
+    {
+        if (images.Count == 0)
+        {
+            throw new ArgumentException("Provide at least one image to stack.", nameof(images));
+        }
+
+        var width = images[0].Width;
+        var height = images[0].Height;
+
+        if (images.Any(image => image.Width != width || image.Height != height))
+        {
+            throw new InvalidOperationException("All frames must share the same resolution before stacking.");
+        }
+
+        var stacked = new Image<Rgba32>(width, height);
+        var totals = new Vector3[width];
+        var frameCount = images.Count;
+
+        for (var y = 0; y < height; y++)
+        {
+            Array.Fill(totals, Vector3.Zero);
+
+            foreach (var image in images)
+            {
+                var sourceRow = image.GetPixelRowSpan(y);
+                for (var x = 0; x < width; x++)
+                {
+                    var pixel = sourceRow[x];
+                    totals[x] += new Vector3(pixel.R, pixel.G, pixel.B);
+                }
+            }
+
+            var destinationRow = stacked.GetPixelRowSpan(y);
+            for (var x = 0; x < width; x++)
+            {
+                var averaged = totals[x] / frameCount;
+                destinationRow[x] = new Rgba32(
+                    (byte)Math.Clamp((int)MathF.Round(averaged.X), 0, 255),
+                    (byte)Math.Clamp((int)MathF.Round(averaged.Y), 0, 255),
+                    (byte)Math.Clamp((int)MathF.Round(averaged.Z), 0, 255),
+                    255);
+            }
+        }
+
+        return stacked;
+    }
+}

--- a/src/SkidbladnirProcessor.App/SkidbladnirProcessor.App.csproj
+++ b/src/SkidbladnirProcessor.App/SkidbladnirProcessor.App.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net7.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
+  </ItemGroup>
+</Project>

--- a/src/SkidbladnirProcessor.App/ViewModels/ProcessedImageViewModel.cs
+++ b/src/SkidbladnirProcessor.App/ViewModels/ProcessedImageViewModel.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using System.Windows.Media.Imaging;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SkidbladnirProcessor.App.ViewModels;
+
+public sealed class ProcessedImageViewModel : IDisposable
+{
+    public ProcessedImageViewModel(string filePath, Image<Rgba32> imageData, BitmapSource preview)
+    {
+        FilePath = filePath;
+        ImageData = imageData;
+        Preview = preview;
+        ProcessedAtUtc = DateTime.UtcNow;
+    }
+
+    public string FilePath { get; }
+
+    public string FileName => Path.GetFileName(FilePath);
+
+    public BitmapSource Preview { get; }
+
+    public Image<Rgba32> ImageData { get; }
+
+    public DateTime ProcessedAtUtc { get; }
+
+    public void Dispose()
+    {
+        ImageData.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- add a .NET 7 WPF application that loads, processes and stacks astrophotography light frames
- implement automatic background calibration, histogram stretch, gentle noise reduction and saturation boost with ImageSharp
- include average stacking, bitmap conversion helpers and documentation for building and using the app

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ca7f58ecf0832099b6af07e1cbf825